### PR TITLE
numeric literal upgrades

### DIFF
--- a/znoc/src/constructions/expression.cpp
+++ b/znoc/src/constructions/expression.cpp
@@ -59,7 +59,8 @@ std::unique_ptr<AST::Expression> Parser::parse_r_value(FILE* f) {
 		case tok_identifier: {
 			return parse_identifier_expression(f);
 		}
-		case tok_numeric_literal: {
+		case tok_decimal_numeric_literal:
+		case tok_integer_numeric_literal: {
 			return parse_numeric_literal(f);
 		}
 		case tok_let: {

--- a/znoc/src/constructions/numeric_literal.cpp
+++ b/znoc/src/constructions/numeric_literal.cpp
@@ -24,7 +24,8 @@ llvm::Value* AST::NumericLiteral::codegen(llvm::IRBuilder<> *builder, __attribut
 // numeric_literal = NUMBER+;
 std::unique_ptr<AST::Expression> Parser::parse_numeric_literal(FILE* f) {
 	//std::cout << "parse numlit" << std::endl;
-	double val = EXPECT_DOUBLE("to start numeric literal");/*std::get<double>(currentTokenVal);
+	bool contains_dp;
+	double val = EXPECT_NUMBERIC_LITERAL("to start numeric literal", contains_dp);/*std::get<double>(currentTokenVal);
 	get_next_token(f); // Move onto token after number*/
 
 	IF_TOK_ELSE_IDENTIFIER(post_num_modifier, {
@@ -32,11 +33,15 @@ std::unique_ptr<AST::Expression> Parser::parse_numeric_literal(FILE* f) {
 		auto modifier_str = post_num_modifier.c_str();
 		auto num_type_char = *(modifier_str++);
 		
-		if (num_type_char != 'u' && num_type_char != 'f') throw UNEXPECTED_CHAR(num_type_char, "`u` or `f` qualifier after number");
+		if (num_type_char != 'u' && num_type_char != 'i' && num_type_char != 'f' ) {
+			throw UNEXPECTED_CHAR(num_type_char, "`u` or `i` or `f` qualifier after number");
+		}
 		auto len = atoi(modifier_str);
-		return num_type_char == 'u' ? AST::NumericLiteral::NewInt(val, len) : AST::NumericLiteral::NewFloat(val, len);
+		return num_type_char == 'u' ? AST::NumericLiteral::NewUInt(val, len) : 
+		       num_type_char == 'i' ? AST::NumericLiteral::NewInt(val, len) :
+			                          AST::NumericLiteral::NewFloat(val, len);
 	}, {
-		return std::make_unique<AST::NumericLiteral>(val);
+		return std::make_unique<AST::NumericLiteral>(val, contains_dp);
 	});
 
 	/*if (currentToken == tok_identifier) {

--- a/znoc/src/constructions/numeric_literal.hpp
+++ b/znoc/src/constructions/numeric_literal.hpp
@@ -16,13 +16,6 @@ namespace AST {
 		} value;
 		bool is_int_val;
 
-		static bool is_int(double v) {
-			uint64_t vi = v;
-			double vc = v - vi;
-			return vc == 0;
-		}
-
-
 		static AST::TypeInstance len_to_ftype(size_t len) {
 			switch (len) {
 				case 16:
@@ -68,10 +61,24 @@ namespace AST {
 			value.i = v;
 		}
 
-		NumericLiteral(double v): Expression(is_int(v) ? (v > UINT32_MAX ? AST::get_fundamental_type("i64") : AST::get_fundamental_type("i32")) : (v > FLT_MAX ? AST::get_fundamental_type("double") : AST::get_fundamental_type("float"))) {
-			is_int_val = is_int(v);
+		NumericLiteral(double v, bool contains_dp): Expression(
+			contains_dp ?
+				(v > FLT_MAX ?
+					AST::get_fundamental_type("double") :
+					AST::get_fundamental_type("float")
+				) :
+				(v > INT32_MAX ?
+					AST::get_fundamental_type("i64") :
+					AST::get_fundamental_type("i32")
+				)
+		) {
+			is_int_val = !contains_dp;
 			if (is_int_val) value.i = v;
 			else value.f = v;
+		}
+
+		static std::unique_ptr<NumericLiteral> NewUInt(uint64_t v, size_t len) {
+			return std::make_unique<AST::NumericLiteral>((uint64_t)v, len);
 		}
 
 		static std::unique_ptr<NumericLiteral> NewInt(uint64_t v, size_t len) {

--- a/znoc/src/constructions/switch.cpp
+++ b/znoc/src/constructions/switch.cpp
@@ -82,7 +82,7 @@ std::pair<AST::SwitchDef::switch_case_metadata_t, std::unique_ptr<AST::CodeBlock
 	EXPECT(tok_case, "inside switch statement");
 
 	while (1) {
-		int val = EXPECT_DOUBLE("numeric literal for case value");
+		int val = EXPECT_NUMBERIC_LITERAL("numeric literal for case value", bool throwaway);
 		meta.num.push_back(llvm::ConstantInt::get(llvm::IntegerType::get(*TheContext, 32), val));
 		if (currentToken == '{') break;
 		EXPECT(',', "or { after case");

--- a/znoc/src/parsing.cpp
+++ b/znoc/src/parsing.cpp
@@ -88,7 +88,11 @@ int get_token(FILE *f) {
 		} while (isdigit(lastChar) || (!foundDecimal && lastChar == '.'));
 
 		currentTokenVal = strtod(number.c_str(), nullptr);
-		return tok_numeric_literal;
+		if (foundDecimal) {
+			return tok_decimal_numeric_literal;
+		} else {
+			return tok_integer_numeric_literal;
+		}
 	}
 
 	if (lastChar == EOF) return tok_eof;

--- a/znoc/src/parsing.hpp
+++ b/znoc/src/parsing.hpp
@@ -24,29 +24,30 @@ enum Token {
 
 	// primary
 	tok_identifier = -5,
-	tok_numeric_literal = -6,
+	tok_integer_numeric_literal = -6,
+	tok_decimal_numeric_literal = -7,
 
 	// typedef
-	tok_struct = -7,
+	tok_struct = -8,
 
 	// control flow
-	tok_if = -8,
-	tok_else = -9,
-	tok_for = -10,
-	tok_throw = -11,
-	tok_switch = -12,
-	tok_case = -13,
-	tok_break = -14,
-	tok_continue = -15,
-	tok_fallthrough = -16,
-	tok_default = -17,
-	tok_while = -18,
+	tok_if = -9,
+	tok_else = -10,
+	tok_for = -11,
+	tok_throw = -12,
+	tok_switch = -13,
+	tok_case = -14,
+	tok_break = -15,
+	tok_continue = -16,
+	tok_fallthrough = -17,
+	tok_default = -18,
+	tok_while = -19,
 
-	tok_uses = -19,
+	tok_uses = -20,
 
-	tok_class = -20,
-	tok_as = -21,
-	tok_typedef = -22
+	tok_class = -21,
+	tok_as = -22,
+	tok_typedef = -23
 };
 
 #include "constructions/namespace.hpp"
@@ -67,8 +68,9 @@ int parse_file(std::filesystem::path p,
 	ret;	\
 })
 
-#define EXPECT_DOUBLE(err) ({ \
-	if (currentToken != tok_numeric_literal) throw UNEXPECTED_CHAR(currentToken, err);	\
+#define EXPECT_NUMBERIC_LITERAL(err, contains_dp) ({ \
+	if (currentToken != tok_decimal_numeric_literal && currentToken != tok_integer_numeric_literal) throw UNEXPECTED_CHAR(currentToken, err);	\
+	contains_dp = currentToken == tok_decimal_numeric_literal;	\
 	auto ret = std::get<double>(currentTokenVal);	\
 	get_next_token(f);	\
 	ret;	\


### PR DESCRIPTION
parsing of numeric literals is now aware of the presence of decimal points, so 5.0 is no longer parsed as an integer